### PR TITLE
Subprotocol-based WebSocket authentication

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -97,6 +97,9 @@ services:
       - CARGO_ENV
     networks:
       - backend
+    depends_on:
+        - sc
+        - spu
 
   presence-service:
     build:

--- a/backend/notification-service/src/jwt.rs
+++ b/backend/notification-service/src/jwt.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use axum::{
     Json, RequestPartsExt,
     extract::FromRequestParts,
-    http::{StatusCode, request::Parts},
+    http::{StatusCode, header, request::Parts},
     response::{IntoResponse, Response},
 };
 use axum_extra::{
@@ -37,24 +37,47 @@ pub(crate) struct Claims {
     pub user_id: String,
 }
 
-impl<S> FromRequestParts<S> for Claims
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Authenticated {
+    pub(crate) claims: Claims,
+    pub(crate) jwt: String,
+}
+
+impl<S> FromRequestParts<S> for Authenticated
 where
     S: Send + Sync,
 {
     type Rejection = AuthError;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        // Extract the token from the authorization header
-        let TypedHeader(Authorization(bearer)) = parts
-            .extract::<TypedHeader<Authorization<Bearer>>>()
-            .await
-            .map_err(|_| AuthError::InvalidToken)?;
-        // Decode the user data
-        let token_data = decode::<Claims>(bearer.token(), &KEYS.decoding, &Validation::default())
-            .map_err(|_| AuthError::InvalidToken)?;
+        if let Ok(TypedHeader(bearer)) = parts.extract::<TypedHeader<Authorization<Bearer>>>().await
+        {
+            let jwt = bearer.token().to_string();
+            let claims = decode_token(&jwt)?;
+            return Ok(Authenticated { claims, jwt });
+        }
 
-        Ok(token_data.claims)
+        // FIXME(Sa4dUs): Collapse these `if let` statements once `Dockerfile` runs rust 2024 edition
+        if let Some(protocol_header) = parts.headers.get(header::SEC_WEBSOCKET_PROTOCOL) {
+            if let Ok(protocols) = protocol_header.to_str() {
+                if let Some(jwt) = protocols.split(',').map(|s| s.trim()).next() {
+                    let claims = decode_token(jwt)?;
+                    return Ok(Authenticated {
+                        claims,
+                        jwt: jwt.to_string(),
+                    });
+                }
+            }
+        }
+
+        Err(AuthError::InvalidToken)
     }
+}
+
+fn decode_token(token: &str) -> Result<Claims, AuthError> {
+    decode::<Claims>(token, &KEYS.decoding, &Validation::default())
+        .map(|data| data.claims)
+        .map_err(|_| AuthError::InvalidToken)
 }
 
 //This should be a common crate for all services, dead code is allowed to preserve the common structure


### PR DESCRIPTION
Allow the client pass JWT Authorization using WebSocket protocols.
`Authorization: Bearer JWT` authentication method was not removed to avoid regression.

This uses the builtin header:
```
Sec-Websocket-Protocol: JWT
```

Example Javascript snippet:
```javascript
let socket = new WebSocket(URL, [JWT_TOKEN])
```