### PR TITLE
Add route wildcards support for api route parsing

### DIFF
--- a/backend/api-gateway/Cargo.lock
+++ b/backend/api-gateway/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +46,7 @@ dependencies = [
  "hyper",
  "jsonwebtoken",
  "rand",
+ "regex",
  "reqwest",
  "serde",
  "tokio",
@@ -1157,6 +1167,35 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/backend/api-gateway/Cargo.toml
+++ b/backend/api-gateway/Cargo.toml
@@ -23,6 +23,7 @@ tokio-tungstenite = "0.27.0"
 futures-util = "0.3.31"
 dashmap = "6.1.0"
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
+regex = "1.11.1"
 
 [lib]
 name = "api_gateway"

--- a/backend/api-gateway/src/middleware/auth.rs
+++ b/backend/api-gateway/src/middleware/auth.rs
@@ -73,8 +73,10 @@ where
                 .unwrap()
                 .routes
                 .iter()
-                .find(|r| r.path == *subpath)
-            {
+                .find(|r| {
+                    let regex = super::router::path_pattern_to_regex(&r.path);
+                    regex.is_match(subpath)
+                }) {
                 Some(r) => r,
                 None => return Ok(StatusCode::NOT_FOUND
                     .with_debug(


### PR DESCRIPTION
Support `/foo/{bar}` kind of routes at config.