### PR TITLE
Minor API Gateway route parsing fix

### DIFF
--- a/backend/api-gateway/src/middleware/auth.rs
+++ b/backend/api-gateway/src/middleware/auth.rs
@@ -67,16 +67,7 @@ where
                 }
             };
 
-            let route = match config
-                .services
-                .get(prefix)
-                .unwrap()
-                .routes
-                .iter()
-                .find(|r| {
-                    let regex = super::router::path_pattern_to_regex(&r.path);
-                    regex.is_match(subpath)
-                }) {
+            let route = match config.get_route(prefix, subpath) {
                 Some(r) => r,
                 None => return Ok(StatusCode::NOT_FOUND
                     .with_debug(

--- a/backend/api-gateway/src/middleware/router.rs
+++ b/backend/api-gateway/src/middleware/router.rs
@@ -70,10 +70,7 @@ where
                 }
             };
 
-            let route = match service.routes.iter().find(|r| {
-                let regex = path_pattern_to_regex(&r.path);
-                regex.is_match(subpath)
-            }) {
+            let route = match service.get_route(subpath) {
                 Some(r) => r,
                 None => {
                     return Ok(StatusCode::NOT_FOUND


### PR DESCRIPTION
This PR fixes a bug that made API select an incorrect route because of the regex matching.

cc @AlexGarciaPrada, who spotted this bug