### PR TITLE
"Variablegate: Dos Días de Oscuridad y una Hora de Batería"

### DIFF
--- a/frontend/src/app/log-in/log-in.component.ts
+++ b/frontend/src/app/log-in/log-in.component.ts
@@ -6,7 +6,7 @@ import { toSignal } from "@angular/core/rxjs-interop";
 import { ErrorsHandling } from "../errors/errors";
 import { SERVER_ROUTE } from "../../environment/environment.secret";
 
-const context = "login";
+const context = "log-in";
 @Component({
     selector: "log-in",
     standalone: true,


### PR DESCRIPTION
En el augusto escenario de nuestro sacrosanto repositorio, donde cada bit se dispone como filigrana en un relicario, y donde las funciones, como coros celestiales, entonan himnos a la estabilidad digital, se ocultaba —como vil usurpador entre los pliegues de una cortina dorada— un ultraje semántico de naturaleza tan nimia en apariencia como devastadora en sus consecuencias: un cambio de nombre de variable incompleto, perpetrado con la insidiosa sutileza de quien coloca una grieta invisible en los cimientos de un palacio.

Durante dos jornadas que parecieron eternidades atrapadas en ámbar, este error, con la majestad maligna de un cardenal conspirador en la penumbra de un concilio, paralizó el frontend entero; las compilaciones se tornaron rebeldes, los despliegues vacilaron como cortejos interrumpidos por una lluvia inoportuna, y el ánimo de la corte de desarrolladores se deslizó hacia un melancólico sopor.

Y he aquí que, armado tan solo con la estoica resignación del condenado y con apenas una hora de energía vital antes de que la tiniebla tecnológica se cierna sobre mi máquina (pues todos los enchufes, esos tronos de poder eléctrico, estaban vilmente ocupados), descendí a las criptas más oscuras del código. Con gesto ceremonioso y pulso de miniaturista borgoñón, arranqué de raíz la afrenta, restituyendo así el honor mancillado de nuestra base de datos de nombres.

Confío en que, tras esta intervención casi litúrgica, la paz y el decoro regresen a nuestras compilaciones, que el frontend se eleve nuevamente como cúpula recién restaurada, y que nunca más una variable —esa humilde súbdita del reino lógico— ose, con tan insolente ligereza, poner en jaque a todo el imperio digital.