### PR TITLE
Duplicate audio fix

### DIFF
--- a/frontend/src/app/groups/call/call.component.ts
+++ b/frontend/src/app/groups/call/call.component.ts
@@ -80,6 +80,7 @@ export class CallComponent {
             audio: true,
         });
         this.localVideoRef.nativeElement.srcObject = this.localStream;
+        this.localVideoRef.nativeElement.muted = true;
 
         this.peerConnection = new RTCPeerConnection(this.configuration);
 


### PR DESCRIPTION
Mute local video reference so you don't hear your own audio track.